### PR TITLE
fix: make `pkg_config::probe` work in `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
 extern crate pkg_config;
 
 fn main() {
-    let probed = pkg_config::Config::new().atleast_version("2.0.0").probe("hwloc");
-    if probed.is_ok() {
-        return;
-    }
+    pkg_config::Config::new()
+        .atleast_version("2.0.0")
+        .probe("hwloc")
+        .unwrap();
 }


### PR DESCRIPTION
Use `unwrap()` instead of `return` in the `build.rs` file to make `pkg_config::probe` work.