### PR TITLE
switch old "hwoloc" references to "hwloc2"

### DIFF
--- a/examples/bind_process.rs
+++ b/examples/bind_process.rs
@@ -1,11 +1,11 @@
-extern crate hwloc;
+extern crate hwloc2;
 extern crate libc;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 #[cfg(target_os = "windows")]
 extern crate kernel32;
 
-use hwloc::{Topology, CpuBindFlags, TopologyObject, ObjectType};
+use hwloc2::{Topology, CpuBindFlags, TopologyObject, ObjectType};
 
 /// Example which binds an arbitrary process (in this example this very same one) to
 /// the last core.

--- a/examples/bind_threads.rs
+++ b/examples/bind_threads.rs
@@ -1,11 +1,11 @@
-extern crate hwloc;
+extern crate hwloc2;
 extern crate libc;
 #[cfg(target_os = "windows")]
 extern crate kernel32;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
-use hwloc::{Topology, ObjectType, CpuBindFlags, CpuSet};
+use hwloc2::{Topology, ObjectType, CpuBindFlags, CpuSet};
 use std::thread;
 use std::sync::{Arc, Mutex};
 

--- a/examples/bind_to_last_core.rs
+++ b/examples/bind_to_last_core.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::{Topology, TopologyObject, ObjectType, CpuBindFlags};
+use hwloc2::{Topology, TopologyObject, ObjectType, CpuBindFlags};
 
 /// Bind to only one thread of the last core of the machine.
 ///

--- a/examples/number_of_packages.rs
+++ b/examples/number_of_packages.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::{Topology, ObjectType, TypeDepthError};
+use hwloc2::{Topology, ObjectType, TypeDepthError};
 
 /// Prints the number of packages.
 fn main() {

--- a/examples/processor_cache.rs
+++ b/examples/processor_cache.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::{Topology, ObjectType};
+use hwloc2::{Topology, ObjectType};
 
 /// Compute the amount of cache that the first logical processor
 /// has above it.

--- a/examples/support.rs
+++ b/examples/support.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::Topology;
+use hwloc2::Topology;
 
 /// Example on how to check for specific topology support of a feature.
 fn main() {

--- a/examples/walk_linear.rs
+++ b/examples/walk_linear.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::Topology;
+use hwloc2::Topology;
 
 /// Walk the topology with an array style, from level 0 (always
 /// the system level) to the lowest level (always the proc level).

--- a/examples/walk_tree.rs
+++ b/examples/walk_tree.rs
@@ -1,6 +1,6 @@
-extern crate hwloc;
+extern crate hwloc2;
 
-use hwloc::{Topology, TopologyObject};
+use hwloc2::{Topology, TopologyObject};
 
 /// Walk the topology in a tree-style and print it.
 fn main() {

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -33,7 +33,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::new();
     /// assert_eq!("", format!("{}", bitmap));
@@ -52,7 +52,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::full();
     /// assert_eq!("0-", format!("{}", bitmap));
@@ -71,7 +71,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::from(1);
     /// assert_eq!("1", format!("{}", bitmap));
@@ -88,7 +88,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::from_range(0, 5);
     /// assert_eq!("0-5", format!("{}", bitmap));
@@ -120,7 +120,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// bitmap.set(4);
@@ -137,7 +137,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// bitmap.set_range(3, 5);
@@ -155,7 +155,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::from_range(1,3);
     /// bitmap.unset(1);
@@ -172,7 +172,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::from_range(1,5);
     /// bitmap.unset_range(4,6);
@@ -190,7 +190,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::from_range(1,5);
     /// assert_eq!(5, bitmap.weight());
@@ -206,7 +206,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::from_range(1,5);
     /// assert_eq!(5, bitmap.weight());
@@ -225,7 +225,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// assert_eq!(true, bitmap.is_empty());
@@ -246,7 +246,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// assert_eq!(false, bitmap.is_set(2));
@@ -267,7 +267,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// bitmap.set_range(0, 127);
@@ -291,7 +291,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let mut bitmap = Bitmap::new();
     /// bitmap.set(3);
@@ -310,7 +310,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::from_range(4,10);
     /// assert_eq!(4, bitmap.first());
@@ -326,7 +326,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let bitmap = Bitmap::from_range(4,10);
     /// assert_eq!(10, bitmap.last());
@@ -340,7 +340,7 @@ impl Bitmap {
     /// Examples:
     ///
     /// ```
-    /// use hwloc::Bitmap;
+    /// use hwloc2::Bitmap;
     ///
     /// let empty_bitmap = Bitmap::new();
     /// assert_eq!(false, empty_bitmap.is_full());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,15 @@
 //! Next, add this to your crate root:
 //!
 //! ```no_run
-//! extern crate hwloc;
+//! extern crate hwloc2;
 //! ```
 //!
 //! Here is a quick example which walks the `Topology` and prints it out:
 //!
 //! ```no_run
-//! extern crate hwloc;
+//! extern crate hwloc2;
 //!
-//! use hwloc::Topology;
+//! use hwloc2::Topology;
 //!
 //! fn main() {
 //! 	let topo = Topology::new().unwrap();
@@ -132,7 +132,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::Topology;
+    /// use hwloc2::Topology;
     ///
     /// let topology = Topology::new();
     /// ```
@@ -168,7 +168,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology, TopologyFlag};
+    /// use hwloc2::{Topology, TopologyFlag};
     ///
     /// let topology = Topology::with_flags(vec![TopologyFlag::IsThisSystem]);
     /// ```
@@ -214,7 +214,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology,TopologyFlag};
+    /// use hwloc2::{Topology,TopologyFlag};
     ///
     /// let default_topology = Topology::new().unwrap();
     /// assert_eq!(0, default_topology.flags().len());
@@ -243,7 +243,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::Topology;
+    /// use hwloc2::Topology;
     ///
     /// let topology = Topology::new().unwrap();
     /// assert!(topology.depth() > 0);
@@ -257,7 +257,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology,ObjectType};
+    /// use hwloc2::{Topology,ObjectType};
     ///
     /// let topology = Topology::new().unwrap();
     ///
@@ -327,7 +327,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology,ObjectType};
+    /// use hwloc2::{Topology,ObjectType};
     ///
     /// let topology = Topology::new().unwrap();
     ///
@@ -355,7 +355,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::Topology;
+    /// use hwloc2::Topology;
     ///
     /// let topology = Topology::new().unwrap();
     ///
@@ -381,7 +381,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology,TopologyObject};
+    /// use hwloc2::{Topology,TopologyObject};
     ///
     /// let topology = Topology::new().unwrap();
     ///
@@ -398,7 +398,7 @@ impl Topology {
     /// # Examples
     ///
     /// ```
-    /// use hwloc::{Topology,ObjectType};
+    /// use hwloc2::{Topology,ObjectType};
     ///
     /// let topology = Topology::new().unwrap();
     ///


### PR DESCRIPTION
fixes places where the old crate name is used in code (tests, examples).

without this change, tests and examples will not build. after the change, the build fine. I assume this is just a vestige from the original codebase.

example error fixed by the changes:

```
error[E0463]: can't find crate for `hwloc`
 --> examples/bind_threads.rs:1:1
  |
1 | extern crate hwloc;
  | ^^^^^^^^^^^^^^^^^^^ can't find crate
```