### PR TITLE
explicitly ignore unused CString to silence unused_must_use warning

### DIFF
--- a/src/topology_object.rs
+++ b/src/topology_object.rs
@@ -239,7 +239,7 @@ impl fmt::Display for TopologyObject {
                                          separator_ptr,
                                          0);
 
-            CString::from_raw(separator_ptr);
+            let _ = CString::from_raw(separator_ptr);
 
             write!(f,
                    "{} ({})",


### PR DESCRIPTION
rustc currently emits the following warning when building the crate:

```
warning: unused return value of `CString::from_raw` that must be used
   --> src/topology_object.rs:242:13
    |
242 |             CString::from_raw(separator_ptr);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(from_raw(ptr))` if you intend to drop the `CString`
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
242 |             let _ = CString::from_raw(separator_ptr);
    |             +++++++
```

This adopts the suggested solution and explicitly ignores the value returned by `CString::from_raw`.

(possibly the line could just be removed, but I had no idea if so as it was gnarly FFI stuff and didn't want to go down that rabbit hole...)